### PR TITLE
chore: add extension packaging workflow

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2024 ChatGPT
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Package Chrome Extension
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - production
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine build mode
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "mode=debug" >> "$GITHUB_OUTPUT"
+            echo "zip=remindify-debug.zip" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref_name }}" == "develop" ]]; then
+            echo "mode=beta" >> "$GITHUB_OUTPUT"
+            echo "zip=remindify-beta.zip" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref_name }}" == "production" ]]; then
+            echo "mode=production" >> "$GITHUB_OUTPUT"
+            echo "zip=remindify.zip" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unsupported branch" >&2
+            exit 1
+          fi
+      - name: Package extension
+        run: |
+          chmod +x package-extension.sh
+          ./package-extension.sh "${{ steps.vars.outputs.mode }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.vars.outputs.mode }}
+          path: dist/${{ steps.vars.outputs.zip }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.crx
 *.pem
 *.zip
+dist/

--- a/package-extension.sh
+++ b/package-extension.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2024 ChatGPT
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+MODE="${1:-debug}"
+OUTDIR="dist"
+
+TMP_DIR=$(mktemp -d)
+ROOT_DIR="$PWD"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cp -r src/* "$TMP_DIR/"
+MANIFEST="$TMP_DIR/manifest.json"
+
+case "$MODE" in
+  debug)
+    jq '.name += " Debug"' "$MANIFEST" > "$TMP_DIR/manifest.tmp" && mv "$TMP_DIR/manifest.tmp" "$MANIFEST"
+    ZIP_NAME="remindify-debug.zip"
+    ;;
+  beta)
+    jq '.name += " Beta"' "$MANIFEST" > "$TMP_DIR/manifest.tmp" && mv "$TMP_DIR/manifest.tmp" "$MANIFEST"
+    ZIP_NAME="remindify-beta.zip"
+    ;;
+  production)
+    ZIP_NAME="remindify.zip"
+    ;;
+  *)
+    echo "Unknown mode: $MODE" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$OUTDIR"
+(
+  cd "$TMP_DIR"
+  zip -r "$ROOT_DIR/$OUTDIR/$ZIP_NAME" .
+)
+
+echo "Created $OUTDIR/$ZIP_NAME"


### PR DESCRIPTION
## Summary
- add script to package extension as debug, beta, or production builds
- run workflow to package on PRs, develop pushes, and production releases

## Testing
- `./package-extension.sh debug`

------
https://chatgpt.com/codex/tasks/task_e_68b967e01f348325adc4fda12566d4a2